### PR TITLE
issue-9: remove googlesiteverification ownership on delete of googlesiteverification_dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ resource "cloudflare_record" "verification" {
 # *After* that, we submit our verification request to Google.
 # Might take some time, depending on Google's DNS caching.
 resource "googlesiteverification_dns" "example" {
-  domain = "yourdomain.example.com"
+  domain     = "yourdomain.example.com"
+  token      = data.googlesiteverification_dns_token.example.record_value
   depends_on = [cloudflare_record.verification] 
 }
 ```

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func Provider() terraform.ResourceProvider {
 					},
 					tokenKey: {
 						Type:     schema.TypeString,
-						Required: true,
+						Required: false,
 						ForceNew: true,
 					},
 				},

--- a/main_test.go
+++ b/main_test.go
@@ -30,21 +30,25 @@ data "googlesiteverification_dns_token" "example" {
 				Config: `
 resource "googlesiteverification_dns" "example" {
 	domain = "test-terraform-provider.hectorj.net"
+        token  = "google-site-verification=deadbeef"
 }`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("googlesiteverification_dns.example", "domain", "test-terraform-provider.hectorj.net"),
+					resource.TestCheckResourceAttr("googlesiteverification_dns.example", "token", "google-site-verification=deadbeef"),
 				),
 			},
 			{
 				Config: `
 resource "googlesiteverification_dns" "example" {
 	domain = "test-terraform-provider.hectorj.net"
+        token  = "google-site-verification=deadbeef"
 }`,
 				ResourceName:      "googlesiteverification_dns.example",
 				ImportState:       true,
 				ImportStateVerify: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("googlesiteverification_dns.example", "domain", "test-terraform-provider.hectorj.net"),
+					resource.TestCheckResourceAttr("googlesiteverification_dns.example", "token", "google-site-verification=deadbeef"),
 				),
 			},
 		},


### PR DESCRIPTION
When you delete a googlesiteverification_dns, your identity is removed as owner of the domain. 

