### PR TITLE
WIP: my work towards the update API (#6) for service accounts

### DIFF
--- a/draft/cloudflare.tf
+++ b/draft/cloudflare.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_record" "google_search_verification_txt" {
+  name    = data.googlesiteverification_dns_token.run_domain.record_name
+  proxied = false
+  ttl     = 3600
+  type    = data.googlesiteverification_dns_token.run_domain.record_type
+  value   = data.googlesiteverification_dns_token.run_domain.record_value
+  zone_id = var.cloudflare_zone_id
+
+  depends_on = [data.googlesiteverification_dns_token.run_domain]
+}

--- a/draft/google.tf
+++ b/draft/google.tf
@@ -1,0 +1,59 @@
+# Enable IAM api
+resource "google_project_service" "iam_api" {
+  service = "iam.googleapis.com"
+}
+
+# Create new service account
+resource "google_service_account" "siteverifier" {
+  account_id   = "google-site-verifier"
+  display_name = "Google Site verification account"
+
+  depends_on = [google_project_service.iam_api]
+}
+
+# Generate service account key
+resource "google_service_account_key" "siteverifier" {
+  service_account_id = google_service_account.siteverifier.name
+}
+
+# Initialise provider with service account key
+provider "googlesiteverification" {
+  credentials = base64decode(google_service_account_key.siteverifier.private_key)
+}
+
+# Enable site verification api
+resource "google_project_service" "siteverification" {
+  service = "siteverification.googleapis.com"
+}
+
+# Request for DNS token from site verification API
+data "googlesiteverification_dns_token" "run_domain" {
+  domain = var.domain_name
+
+  depends_on = [google_project_service.siteverification]
+}
+
+# Request google to verify the newly added verification record
+resource "googlesiteverification_dns" "run_domain" {
+  domain = var.domain_name
+  token  = data.googlesiteverification_dns_token.run_domain.record_value
+
+  depends_on = [cloudflare_record.google_search_verification_txt]
+}
+
+# Get the details of the verification
+data "googlesiteverification_site_details" "test" {
+  resource_id = googlesiteverification_dns.run_domain.id
+
+  depends_on = [googlesiteverification_dns.run_domain]
+}
+
+# Add the details of the new owner
+resource "googlesiteverification_add_owner" "test" {
+  resource_id             = data.googlesiteverification_site_details.test.id
+  site_details_type       = data.googlesiteverification_site_details.test.site_details_type
+  site_details_identifier = data.googlesiteverification_site_details.test.site_details_identifier
+  owner_details           = concat(data.googlesiteverification_site_details.test.owner_details, ["emailAddress"])
+
+  depends_on = [data.googlesiteverification_site_details.test]
+}


### PR DESCRIPTION
I tried to use a service account and ran into issues, I saw #3  and #6 so thought I would give it a go, I had never written go so it is a but touch, but is a starting point if someone else wants to puck it up further.

the drafts dir has the 2 tf files I had written. 

Issues:
- need to run create the service account first then run a normal apply
- need a better way to add the email address as it was trying to add it each time it ran
- to delete, you need to remove the DNS record, not sure how you would link out to something else to destroy it 
- url encoding/decoding was fun, it doesn't give it to you in a way you could give it back
- you still need to manually add it to your search console, it is just pre-verified

[I also wrote a blog post about what I need to do to get this all to work](https://smale.codes/posts/terraforming-the-google-search-key/)